### PR TITLE
Convert table components to use context

### DIFF
--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -1,12 +1,6 @@
 import React from 'react'
-import { Row, Cell, TableBodyProps } from 'react-table'
-
-interface BodyProps {
-  /** Header Group used to create the header TRs */
-  rows: Array<Row>
-  tableBodyProps: TableBodyProps
-  prepareRow: (row: Row) => void;
-}
+import { Row, Cell } from 'react-table'
+import useTableContext from './useTableContext'
 
 interface TrProps {
   row: Row
@@ -34,11 +28,13 @@ const Tr: React.FC<TrProps> = (props) => {
   )
 }
 
-const Body: React.FC<BodyProps> = (props) => {
+const Body: React.FC = () => {
+  const { getTableBodyProps, rows, prepareRow } = useTableContext()
+
   return (
-    <tbody data-testid={props['data-testid'] || 'table-tbody'} {...props.tableBodyProps}>
-      {props.rows.map((row, index) => {
-        props.prepareRow(row)
+    <tbody data-testid='table-tbody' {...getTableBodyProps()}>
+      {rows.map((row, index) => {
+        prepareRow(row)
         return (
           <Tr row={row} key={index} />
         )

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,10 +1,6 @@
 import React from 'react'
 import { HeaderGroup, ColumnInstance } from 'react-table'
-
-interface HeaderProps {
-  /** Header Group used to create the header TRs */
-  headerGroups: Array<HeaderGroup>
-}
+import useTableContext from './useTableContext'
 
 interface TrProps {
   headerGroup: HeaderGroup
@@ -32,10 +28,12 @@ const Tr: React.FC<TrProps> = (props) => {
   )
 }
 
-const Header: React.FC<HeaderProps> = (props) => {
+const Header: React.FC = (props) => {
+  const { headerGroups } = useTableContext()
+
   return (
-    <thead data-testid={props['data-testid'] || 'table-thead'}>
-      {props.headerGroups.map((headerGroup, index) => (
+    <thead data-testid={'table-thead'}>
+      {headerGroups.map((headerGroup, index) => (
         <Tr headerGroup={headerGroup} key={index} />
       ))}
     </thead>

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1,38 +1,61 @@
 import React from 'react'
-import { useTable, Column } from 'react-table'
+import { Column } from 'react-table'
 import { Table as StrapTable } from 'reactstrap'
 import Header from './Header'
 import Body from './Body'
+import useTableContext from './useTableContext'
+import TableContext, { Context } from './TableContext'
 
-interface TableProps {
-  columns: Array<Column>
-  data: Array<object>
+interface TableProps extends Partial<BaseTableProps> {
+  columns?: Array<Column>
+  data?: Array<object>
+}
+interface BaseTableProps {
   "data-testid"?: string
 }
 
 /**
- * 
- * @example [Basic Example](../storybook/index.html??path=/story/welcome--basic)
+ * Base Table component with no context injection.
+ *  
+ * @private
  */
-const Table: React.FC<TableProps> = (props) => {
-  const {
-    getTableBodyProps,
-    getTableProps,
-    headerGroups,
-    prepareRow,
-    rows,
-  } = useTable({
-    columns: props.columns,
-    data: props.data
-  })
+const BaseTable: React.FC<BaseTableProps> = (props) => {
+  const { getTableProps } = useTableContext() 
 
   return (
     <StrapTable data-testid={ props['data-testid'] || 'table' } {...getTableProps()}>
-      <Header headerGroups={headerGroups} />
-      <Body prepareRow={prepareRow} rows={rows} tableBodyProps={getTableBodyProps()} />
+      <Header />
+      <Body />
     </StrapTable>
   )
 }
+
+/**
+ * Standard Table component joining [reactstrap](https://github.com/reactstrap/reactstrap)
+ * and [react-table](https://github.com/tannerlinsley/react-table).
+ * 
+ * @see [[TableContext]] for exending the table to add on other features.
+ * 
+ * @example [Basic Example](../storybook/index.html?path=/story/reactstrap-table--basic)
+ */
+const Table: React.FC<TableProps> = (props) => { 
+  const tableState = React.useContext(Context)
+
+  if (tableState === null && (!props.columns || !props.data)) {
+    throw new Error('If Table is not wrapped in a TableContext you must pass column and data props.')
+  }
+
+  if (tableState === null && props.columns && props.data) {
+    return (
+      <TableContext columns={props.columns} data={props.data}>
+        <BaseTable />  
+      </TableContext>
+    )
+  } else if (tableState !== null ) {
+    return <BaseTable />
+  }
+  return null
+ }
 
 export default Table
 export { TableProps }

--- a/src/TableContext.tsx
+++ b/src/TableContext.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { useTable, Column, TableInstance } from 'react-table'
+
+interface TableProps {
+  columns: Array<Column>
+  data: Array<object>
+  "data-testid"?: string
+}
+
+type TableState = TableInstance | null
+
+const Context = React.createContext<TableState>(null)
+
+/**
+ * Context wrapper around the [[Table]] component. See [[useTableContext]] to
+ * access the table state from within TableContext.
+ *
+ * @example [Table Context Example](../storybook/index.html?path=/story/reactstrap-table--with-context)
+ */
+const TableContext: React.FC<TableProps> = (props) => {
+  const state = useTable({
+    columns: props.columns,
+    data: props.data
+  })
+
+
+  return (
+    <Context.Provider value={state}>
+      {props.children}
+    </Context.Provider>
+  )
+}
+
+export default TableContext
+export { Context, TableState }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
 import Table from './Table'
+import TableContext from './TableContext'
+import useTableContext from './useTableContext'
 
-export { Table }
+export { Table, TableContext, useTableContext }

--- a/src/useTableContext.tsx
+++ b/src/useTableContext.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+import { Context } from './TableContext'
+import { TableInstance } from 'react-table'
+
+const useTableContext = () => {
+  const state = React.useContext(Context) 
+  if (state === null) {
+    throw new Error('Table state not setup. Please use within TableContext!')
+  }
+  return state as TableInstance
+}
+
+export default useTableContext

--- a/stories/context.stories.tsx
+++ b/stories/context.stories.tsx
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+import { Table, TableContext, useTableContext } from '../src';
+
+import 'bootstrap/dist/css/bootstrap.min.css'
+import { Container, Row, Col } from 'reactstrap';
+
+export default {
+  title: 'reactstrap-table',
+  component: Table
+}
+
+const DisplayColumnJson = () => {
+  const { columns } = useTableContext()
+  return (
+    <Row>
+      <Col className='bg-light col-11 mx-auto'>
+        <pre>
+          {JSON.stringify(columns, null, 2)}
+        </pre>
+      </Col>
+    </Row>
+  )
+}
+
+export const WithContext = () => {
+  const columns = [
+    { Header: 'First Name', accessor: 'firstname'},
+    { Header: 'Last Name', accessor: 'lastname'}
+  ]
+
+  const data = [
+    { firstname: 'John', lastname: 'Doe' },
+    { firstname: 'Jane', lastname: 'Smith'}
+  ]
+
+  return (
+    <Container fluid>
+      <Row>
+        <Col>
+          <TableContext columns={columns} data={data}>
+            <Table />
+            <DisplayColumnJson />
+          </TableContext>
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+WithContext.story = {
+  name: 'Table Context',
+};

--- a/tests/body.test.tsx
+++ b/tests/body.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import {render } from '@testing-library/react'
-import { useTable } from 'react-table'
+import { render } from '@testing-library/react'
 
 import Body from '../src/Body'
+import { TableContext } from '../src';
 
 test('Table Header has rendered with proper columns', () => {
   const columns = [
@@ -16,18 +16,12 @@ test('Table Header has rendered with proper columns', () => {
   ]
 
   const Component = () => {
-    const {
-      rows,
-      prepareRow,
-      getTableBodyProps
-    } = useTable({
-      columns,
-      data
-    })
     return (
-      <table>
-        <Body rows={rows} prepareRow={prepareRow} tableBodyProps={getTableBodyProps()} />
-      </table>
+      <TableContext columns={columns} data={data}>
+        <table>
+          <Body />
+        </table>
+      </TableContext>
     )
   }
 

--- a/tests/header.test.tsx
+++ b/tests/header.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import {render } from '@testing-library/react'
-import { useTable } from 'react-table'
+import { render } from '@testing-library/react'
 
 import Header from '../src/Header'
+import { TableContext } from '../src'
 
 test('Table Header has rendered with proper columns', () => {
   const columns = [
@@ -16,16 +16,12 @@ test('Table Header has rendered with proper columns', () => {
   ]
 
   const Component = () => {
-    const {
-      headerGroups
-    } = useTable({
-      columns,
-      data
-    })
     return (
-      <table>
-        <Header headerGroups={headerGroups} />
-      </table>
+      <TableContext columns={columns} data={data}>
+        <table>
+          <Header />
+        </table>
+      </TableContext>
     )
   }
 

--- a/tests/table.test.tsx
+++ b/tests/table.test.tsx
@@ -1,19 +1,84 @@
 import React from 'react'
 import {render} from '@testing-library/react'
 
-import { Table } from '../src'
+import { Table, TableContext, useTableContext } from '../src'
 
-test('Table Has Rendered', () => {
-  const columns = [
-    { Header: 'First Name', accessor: 'firstname'},
-    { Header: 'Last Name', accessor: 'lastname'}
-  ]
+const columns = [
+  { Header: 'First Name', accessor: 'firstname' },
+  { Header: 'Last Name', accessor: 'lastname' }
+]
 
-  const data = [
-    { firstname: 'John', lastname: 'Doe' },
-    { firstname: 'Jane', lastname: 'Smith'}
-  ]
+const data = [
+  { firstname: 'John', lastname: 'Doe' },
+  { firstname: 'Jane', lastname: 'Smith' }
+]
 
+let original = {
+  error: console.error,
+  warn: console.warn
+}
+
+const silenceConsole = () => {
+  Object.keys(original).forEach(key => {
+    console[key] = (msg: string) => null
+  })
+}
+
+const resetConsole = () => {
+  Object.keys(original).forEach(key => {
+    console[key] = original[key]
+  })
+}
+
+afterEach(() => {
+  resetConsole()
+})
+
+test('Table without Context', () => {
   const { queryByTestId } = render(<Table columns={columns} data={data} />)
-  expect(queryByTestId('table')).toBeTruthy()
+  expect(queryByTestId('table')).toBeInTheDocument()
+});
+
+test('Table without Context or Table props', () => {
+  silenceConsole() //Suppress console messages
+
+  // Throw error because of missing props and no context
+  expect(() => render(<Table />)).toThrowError()
+});
+
+test('Table With Context', () => {
+  const Component = () => {
+    return (
+      <TableContext columns={columns} data={data}>
+        <Table />
+      </TableContext>
+    ) 
+  }
+
+  const { queryByTestId } = render(<Component />)
+  expect(queryByTestId('table')).toBeInTheDocument()
+});
+
+test('Use context without provider should throw', () => {
+  silenceConsole() //Suppress warning from console.error
+
+  const InnerComponent = () => {
+    const { columns } = useTableContext()
+    return (
+      <pre>
+        {JSON.stringify(columns)}
+      </pre>
+    )
+  }
+
+  const Component = () => {
+    return (
+      <>
+        <Table columns={columns} data={data} />
+        <InnerComponent />
+      </>
+    ) 
+  }
+
+  expect(() => render(<Component />)).toThrow()
 });

--- a/typedoc.json
+++ b/typedoc.json
@@ -10,6 +10,11 @@
         "Table": "_table_",
         "Header": "_header_",
         "Body": "_body_"
+      },
+      "Table Context": {
+        "TableContext": "_TableContext_",
+        "useTableContext": "_useTableContext_",
+        "Context": "_tablecontext_.html#context"
       }
     }]
 }


### PR DESCRIPTION
## Changes

### `new` \<TableContext \/\>

Create a context provider around a table component. This can be use to extend the table and provide the table state outside of the `<Table />` component. This also prevents prop drilling within the Table.

### `new` useTableContext()

Access the table state from the `TableContext` provider. This hook must be used within the context provider or it will throw an error.

### `updated` \<Table \/\>

Updated the Table component to create a `TableContext` provider if one has not already been created.

### `updated` \<Header \/\> and \<Body \/\>

Updated the Header and Body components to leverage the `useTableContext` hook.