### PR TITLE
Table Control Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.27",
     "@fortawesome/free-solid-svg-icons": "^5.12.1",
     "@fortawesome/react-fontawesome": "^0.1.9",
+    "react-beautiful-dnd": "^13.0.0",
     "react-table": "^7.0.0"
   },
   "devDependencies": {
@@ -47,6 +48,7 @@
     "@types/babel__core": "^7.1.6",
     "@types/jest": "^25.1.4",
     "@types/react": "^16.9.23",
+    "@types/react-beautiful-dnd": "^12.1.2",
     "@types/react-dom": "^16.9.5",
     "@types/react-table": "7.0.12",
     "@types/reactstrap": "^8.4.2",

--- a/src/ColumnControl/ColumnControl.tsx
+++ b/src/ColumnControl/ColumnControl.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { 
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalFooter,
+  Button
+} from 'reactstrap'
+import ColumnList from './ColumnList'
+import useTableContext from '../useTableContext'
+
+interface ColumnControlProps {
+  open: boolean
+  toggle: React.MouseEventHandler<any>
+}
+
+/**
+ * Reactstrap Modal for Column Visibility Settings. Control the modal visibility
+ * through the `open` and `toggle` props.
+ * 
+ * @param props 
+ */
+const ColumnControl: React.FC<ColumnControlProps> = (props) => {
+  const { allColumns } = useTableContext()
+
+  return (
+    <Modal data-testid='column-control' isOpen={props.open}>
+      <ModalHeader toggle={props.toggle}>Column Controls</ModalHeader>
+      <ModalBody>
+          <ColumnList columns={allColumns} />
+      </ModalBody>
+      <ModalFooter>
+        <Button color='danger'>Reset Columns</Button>
+      </ModalFooter>
+    </Modal>
+  )
+}
+
+export default ColumnControl

--- a/src/ColumnControl/ColumnControl.tsx
+++ b/src/ColumnControl/ColumnControl.tsx
@@ -21,7 +21,11 @@ interface ColumnControlProps {
  * @param props 
  */
 const ColumnControl: React.FC<ColumnControlProps> = (props) => {
-  const { allColumns } = useTableContext()
+  const { allColumns, setHiddenColumns, initialState } = useTableContext()
+
+  const reset = () => {
+    setHiddenColumns(initialState.hiddenColumns || [])
+  }
 
   return (
     <Modal data-testid='column-control' isOpen={props.open}>
@@ -30,7 +34,7 @@ const ColumnControl: React.FC<ColumnControlProps> = (props) => {
           <ColumnList columns={allColumns} />
       </ModalBody>
       <ModalFooter>
-        <Button color='danger'>Reset Columns</Button>
+        <Button color='danger' data-testid='reset-columns' onClick={reset}>Reset Columns</Button>
       </ModalFooter>
     </Modal>
   )

--- a/src/ColumnControl/ColumnItem.tsx
+++ b/src/ColumnControl/ColumnItem.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
+import { ColumnInstance } from 'react-table'
+
+interface IconProps {
+  active: boolean,
+  toggle: React.MouseEventHandler<any>
+}
+
+/**
+ * Visibility Icon displays the current visible/hidden state using the `acitve`
+ * prop.
+ * 
+ * @private
+ * 
+ * @param props 
+ */
+const Icons: React.FC<IconProps> = (props) => { 
+  const iconProps = {
+    fixedWidth: true,
+    className: 'mr-1',
+    style: { cursor: 'pointer' },
+    onClick: props.toggle
+  }
+  if (props.active) {
+    return <FontAwesomeIcon data-testid='column-visibility-icon-visible' icon={faEye} {...iconProps} />
+  } else {
+    return <FontAwesomeIcon data-testid='column-visibility-icon-hidden' icon={faEyeSlash} {...iconProps} />
+  }
+}
+
+interface ColumnItemProps {
+  column: ColumnInstance
+}
+
+/**
+ * Table Column item in a list group. An Icon is displayed next to the column
+ * header that toggles the visiblity of the column.
+ * 
+ * @private
+ * 
+ * @param props 
+ */
+const ColumnItem: React.FC<ColumnItemProps> = (props) => {
+  const active = props.column.isVisible
+  return (
+    <li className={`list-group-item ${!active ? 'bg-light' : ''}`} >
+      <Icons active={active} toggle={() => props.column.toggleHidden()} />
+      {props.column.Header}
+    </li>
+  )
+}
+
+export default ColumnItem

--- a/src/ColumnControl/ColumnItem.tsx
+++ b/src/ColumnControl/ColumnItem.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons'
 import { ColumnInstance } from 'react-table'
+import { Draggable, DraggableProvided } from 'react-beautiful-dnd'
 
 interface IconProps {
   active: boolean,
@@ -30,8 +31,46 @@ const Icons: React.FC<IconProps> = (props) => {
   }
 }
 
+interface ItemProps {
+  column: ColumnInstance
+  provided?: DraggableProvided
+}
+
+/**
+ * Table Column item in a list group. An Icon is displayed next to the column
+ * header that toggles the visiblity of the column.
+ * 
+ * @private
+ * 
+ * @param props 
+ */
+const Item: React.FC<ItemProps> = (props) => {
+  const active = props.column.isVisible
+  const { provided } = props
+  let itemProps = {}
+  if (provided) {
+    itemProps = {
+      ...itemProps,
+      ...provided.draggableProps,
+      ...provided.dragHandleProps,
+      ref: provided.innerRef
+    }
+  }
+  return (
+    <li 
+      data-testid='column-control-item'
+      className={`list-group-item ${!active ? 'bg-light' : ''}`}
+      {...itemProps}
+    >
+      <Icons active={active} toggle={() => props.column.toggleHidden()} />
+      {props.column.Header}
+    </li>
+  )
+}
 interface ColumnItemProps {
   column: ColumnInstance
+  index: number
+  draggable?: boolean
 }
 
 /**
@@ -43,12 +82,21 @@ interface ColumnItemProps {
  * @param props 
  */
 const ColumnItem: React.FC<ColumnItemProps> = (props) => {
-  const active = props.column.isVisible
+  const { column, index, draggable } = props
   return (
-    <li className={`list-group-item ${!active ? 'bg-light' : ''}`} >
-      <Icons active={active} toggle={() => props.column.toggleHidden()} />
-      {props.column.Header}
-    </li>
+    <>
+      { draggable
+        ? (
+          <Draggable key={column.id} draggableId={column.id} index={index}>
+            {provided => (
+              <Item column={column} provided={provided} />
+            )}
+          </Draggable>
+        ) : (
+          <Item column={column} />
+        )
+      }
+    </>
   )
 }
 

--- a/src/ColumnControl/ColumnList.tsx
+++ b/src/ColumnControl/ColumnList.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import ColumnItem from './ColumnItem'
+import { ColumnInstance } from 'react-table'
+
+interface ColumnListProps {
+  columns: Array<ColumnInstance>
+}
+
+/**
+ * List group of all columns.
+ * 
+ * @private
+ * 
+ * @param props 
+ */
+const ColumnList: React.FC<ColumnListProps> = (props) => {
+  const { columns } = props
+  return (
+    <ul className='list-group'>
+      {columns.map((column, index) => (
+        <ColumnItem
+          key={index}
+          column={column}
+        />
+      ))}
+    </ul>
+  )
+}
+
+export default ColumnList

--- a/src/ColumnControl/ColumnList.tsx
+++ b/src/ColumnControl/ColumnList.tsx
@@ -2,9 +2,16 @@ import React from 'react'
 
 import ColumnItem from './ColumnItem'
 import { ColumnInstance } from 'react-table'
+import { Droppable, DroppableProvided } from 'react-beautiful-dnd'
 
 interface ColumnListProps {
   columns: Array<ColumnInstance>
+  draggable?: boolean
+}
+
+interface ListProps {
+  columns: Array<ColumnInstance>
+  provider?: DroppableProvided
 }
 
 /**
@@ -14,17 +21,56 @@ interface ColumnListProps {
  * 
  * @param props 
  */
-const ColumnList: React.FC<ColumnListProps> = (props) => {
-  const { columns } = props
+const List: React.FC<ListProps> = (props) => {
+  const { columns, provider } = props
+  let listProps = {}
+  if (provider) {
+    listProps = {
+      ...listProps,
+      ...provider.droppableProps,
+      ref: provider.innerRef
+    }
+  }
   return (
-    <ul className='list-group'>
+    <ul className='list-group' {...listProps}>
       {columns.map((column, index) => (
         <ColumnItem
           key={index}
+          index={index}
           column={column}
+          draggable={provider ? true : false}
         />
       ))}
+      { provider ? provider.placeholder : null }
     </ul>
+  )
+}
+
+/**
+ * List wrapper to provide drag and drop support for column ordering
+ * 
+ * @private
+ * 
+ * @param props 
+ */
+const ColumnList: React.FC<ColumnListProps> = (props) => {
+  const { columns } = props
+  return (
+    <>
+      { props.draggable
+        ? (
+          <Droppable droppableId='table-columns'>
+            {(provider) => {
+              return (
+                <List columns={columns} provider={provider} />
+              )
+            }}
+          </Droppable>
+        ) : (
+          <List columns={columns} />
+        )
+      }
+    </>
   )
 }
 

--- a/src/ColumnControl/index.tsx
+++ b/src/ColumnControl/index.tsx
@@ -1,0 +1,3 @@
+import ColumnControl from './ColumnControl'
+
+export { ColumnControl }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,5 +2,6 @@ import Table from './Table'
 import TableContext from './TableContext'
 import useTableContext from './useTableContext'
 import GlobalSearch, { globalSearchFilter } from './GlobalSearch'
+import { ColumnControl } from './ColumnControl'
 
-export { Table, TableContext, useTableContext, globalSearchFilter, GlobalSearch }
+export { Table, TableContext, useTableContext, globalSearchFilter, GlobalSearch, ColumnControl }

--- a/stories/ColumnControl.stories.tsx
+++ b/stories/ColumnControl.stories.tsx
@@ -3,6 +3,7 @@ import { Table, TableContext, ColumnControl, useTableContext } from '../src';
 
 import 'bootstrap/dist/css/bootstrap.min.css'
 import { Container, Row, Col, Button } from 'reactstrap';
+import { useColumnOrder } from 'react-table';
 
 export default {
   title: 'reactstrap-table',
@@ -10,10 +11,10 @@ export default {
 }
 
 const State = () => {
-  const { state } = useTableContext()
+  const table = useTableContext()
   return (
     <pre>
-      {JSON.stringify(state, null, 2)}
+      {JSON.stringify(table.state, null, 2)}
     </pre>
   )
 }
@@ -34,7 +35,7 @@ export const ColumnControlExample = () => {
     <Container fluid>
       <Row>
         <Col>
-          <TableContext options={{ columns, data }}>
+          <TableContext options={{ columns, data }} plugins={[useColumnOrder]}>
             <Button onClick={() => setOpen(s => !s)}>Open Settings</Button>
             <ColumnControl open={open} toggle={() => setOpen(o => !o)}/>
             <Table />

--- a/stories/ColumnControl.stories.tsx
+++ b/stories/ColumnControl.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Table, TableContext, ColumnControl, useTableContext } from '../src';
+
+import 'bootstrap/dist/css/bootstrap.min.css'
+import { Container, Row, Col, Button } from 'reactstrap';
+
+export default {
+  title: 'reactstrap-table',
+  component: Table
+}
+
+const State = () => {
+  const { state } = useTableContext()
+  return (
+    <pre>
+      {JSON.stringify(state, null, 2)}
+    </pre>
+  )
+}
+
+export const ColumnControlExample = () => {
+  const [ open, setOpen ] = React.useState(false)
+  const columns = React.useMemo(() => [
+    { Header: 'First Name', accessor: 'firstname'},
+    { Header: 'Last Name', accessor: 'lastname'}
+  ], [])
+
+  const data = React.useMemo(() => [
+    { firstname: 'John', lastname: 'Doe' },
+    { firstname: 'Jane', lastname: 'Smith'}
+  ], [])
+
+  return (
+    <Container fluid>
+      <Row>
+        <Col>
+          <TableContext options={{ columns, data }}>
+            <Button onClick={() => setOpen(s => !s)}>Open Settings</Button>
+            <ColumnControl open={open} toggle={() => setOpen(o => !o)}/>
+            <Table />
+            <State />
+          </TableContext>
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+ColumnControlExample.story = {
+  name: 'Column Control',
+};

--- a/tests/ColumnControl.test.tsx
+++ b/tests/ColumnControl.test.tsx
@@ -76,3 +76,61 @@ test('Visiblity Toggle', async () => {
     expect(tds.length).toBe(2)
   })
 });
+
+test('Reset Column Visiblity Without initialState', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId, getByTestId } = render(<Component />)
+  const visiblityControls = getAllByTestId('column-visibility-icon-visible')
+  fireEvent.click(visiblityControls[0])
+  await waitFor(() => {
+    const visiblityControlsHidden = getAllByTestId('column-visibility-icon-hidden')
+    expect(visiblityControlsHidden.length).toBe(1)
+  })
+  fireEvent.click(getByTestId('reset-columns'))
+  await waitFor(() => {
+    const visiblityControls = getAllByTestId('column-visibility-icon-visible')
+    expect(visiblityControls.length).toBe(2)
+    const ths = getAllByTestId('table-thead-tr-th')
+    const tds = getAllByTestId('table-tbody-tr-td')
+    expect(ths.length).toBe(2)
+    expect(tds.length).toBe(4)
+  })
+});
+
+test('Reset Column Visiblity with initialState', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data, initialState: { hiddenColumns: ['firstname'] }}}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId, getByTestId } = render(<Component />)
+  const visiblityControls = getAllByTestId('column-visibility-icon-hidden')
+  fireEvent.click(visiblityControls[0])
+  await waitFor(() => {
+    const visiblityControlsHidden = getAllByTestId('column-visibility-icon-visible')
+    expect(visiblityControlsHidden.length).toBe(2)
+  })
+  fireEvent.click(getByTestId('reset-columns'))
+  await waitFor(() => {
+    const visiblityControls = getAllByTestId('column-visibility-icon-visible')
+    const visiblityControlsHidden = getAllByTestId('column-visibility-icon-hidden')
+    expect(visiblityControls.length).toBe(1)
+    expect(visiblityControlsHidden.length).toBe(1)
+    const ths = getAllByTestId('table-thead-tr-th')
+    const tds = getAllByTestId('table-tbody-tr-td')
+    expect(ths.length).toBe(1)
+    expect(tds.length).toBe(2)
+  })
+});

--- a/tests/ColumnControl.test.tsx
+++ b/tests/ColumnControl.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { Button } from 'reactstrap'
+
+// @ts-ignore
+import 'regenerator-runtime/runtime'
+
+// @ts-ignore
+import { render, fireEvent, waitFor } from '@testing-library/react'
+
+import { Table, TableContext, ColumnControl } from '../src';
+
+const columns = [
+  { Header: 'First Name', accessor: 'firstname' },
+  { Header: 'Last Name', accessor: 'lastname' }
+]
+
+const data = [
+  { firstname: 'John', lastname: 'Doe' },
+  { firstname: 'Jane', lastname: 'Smith' }
+]
+
+test('Modal open and toggle props', async () => {
+  const Component = () => {
+    const [ open, setOpen ] = React.useState(false)
+    return (
+      <TableContext options={{ columns, data }}>
+        <Button data-testid='open-controls' onClick={() => setOpen(true)}>
+          Open
+        </Button>
+        <ColumnControl open={open} toggle={() => setOpen(o => !o)} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getByTestId, queryByTestId, getByLabelText } = render(<Component />)
+  let modal = queryByTestId('column-control')
+
+  // Default closed
+  expect(modal).not.toBeInTheDocument()
+
+  // Open Dialog
+  fireEvent.click(getByTestId('open-controls'))
+  modal = queryByTestId('column-control')
+  expect(modal).toBeVisible()
+
+  // Close Dialog
+  const close = getByLabelText('Close') 
+  fireEvent.click(close)
+  await waitFor(() => {
+    modal = queryByTestId('column-control')
+    expect(modal).not.toBeInTheDocument()
+  })
+});
+
+test('Visiblity Toggle', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId } = render(<Component />)
+  const visiblityControls= getAllByTestId('column-visibility-icon-visible')
+  expect(visiblityControls.length).toBe(2)
+  fireEvent.click(visiblityControls[0])
+  await waitFor(() => {
+    const visiblityControlsHidden = getAllByTestId('column-visibility-icon-hidden')
+    expect(visiblityControlsHidden.length).toBe(1)
+    const ths = getAllByTestId('table-thead-tr-th')
+    const tds = getAllByTestId('table-tbody-tr-td')
+    expect(ths.length).toBe(1)
+    expect(tds.length).toBe(2)
+  })
+});

--- a/tests/ColumnControl.test.tsx
+++ b/tests/ColumnControl.test.tsx
@@ -3,11 +3,11 @@ import { Button } from 'reactstrap'
 
 // @ts-ignore
 import 'regenerator-runtime/runtime'
-
 // @ts-ignore
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { render, fireEvent, waitFor, getByTestId, getAllByTestId } from '@testing-library/react'
 
 import { Table, TableContext, ColumnControl } from '../src';
+import { useColumnOrder } from 'react-table'
 
 const columns = [
   { Header: 'First Name', accessor: 'firstname' },
@@ -132,5 +132,94 @@ test('Reset Column Visiblity with initialState', async () => {
     const tds = getAllByTestId('table-tbody-tr-td')
     expect(ths.length).toBe(1)
     expect(tds.length).toBe(2)
+  })
+});
+
+test('Rearrange Columns without initialState', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }} plugins={[useColumnOrder]}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId } = render(<Component />)
+
+  // Verify starting order
+  const ths = getAllByTestId('table-thead-tr-th')
+  expect(ths[0].textContent).toBe('First Name')
+  expect(ths[1].textContent).toBe('Last Name')
+
+  // Drag first name
+  const firstNameControl = getAllByTestId('column-control-item')[0]
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 40 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+
+  await waitFor(() => {
+    // Verify order after sort
+    const ths_post_drag = getAllByTestId('table-thead-tr-th')
+    expect(ths_post_drag[0].textContent).toBe('Last Name')
+    expect(ths_post_drag[1].textContent).toBe('First Name')
+  })
+});
+
+test('Reset after rearrange columns without initialState', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }} plugins={[useColumnOrder]}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId, getByTestId } = render(<Component />)
+
+  // Drag first name
+  const firstNameControl = getAllByTestId('column-control-item')[0]
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 40 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+  
+  // Reset Columns
+  fireEvent.click(getByTestId('reset-columns'))
+
+  await waitFor(() => {
+    // Verify order after sort
+    const ths_post_reset = getAllByTestId('table-thead-tr-th')
+    expect(ths_post_reset[0].textContent).toBe('First Name')
+    expect(ths_post_reset[1].textContent).toBe('Last Name')
+  })
+});
+
+test('Reset after rearrange columns with initialState', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data, initialState: { columnOrder: ['lastname', 'firstname']}}} plugins={[useColumnOrder]}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId, getByTestId } = render(<Component />)
+
+  // Drag first name
+  const lastNameControl = getAllByTestId('column-control-item')[0]
+  fireEvent.keyDown(lastNameControl, { keyCode: 32 });
+  fireEvent.keyDown(lastNameControl, { keyCode: 40 });
+  fireEvent.keyDown(lastNameControl, { keyCode: 32 });
+  
+  // Reset Columns
+  fireEvent.click(getByTestId('reset-columns'))
+
+  await waitFor(() => {
+    // Verify order after sort
+    const ths_post_reset = getAllByTestId('table-thead-tr-th')
+    expect(ths_post_reset[0].textContent).toBe('Last Name')
+    expect(ths_post_reset[1].textContent).toBe('First Name')
   })
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,8 @@
   },
   "include": [
     "src/**/*",
+    "tests/**/*",
+    "stories/**/*"
   ],
   "exclude": [
     "node_modules",

--- a/typedoc.json
+++ b/typedoc.json
@@ -23,6 +23,9 @@
       "Global Search": {
         "GlobalSearch": "_GlobalSearch_.html#globalsearch",
         "globalSearchFilter": "_GlobalSearch_.html#globalsearchfilter"
+      },
+      "Column Control": {
+        "ColumnControl": "_columncontrol_columncontrol_"
       }
     }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,6 +1939,13 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-beautiful-dnd@^12.1.2":
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-12.1.2.tgz#dfd1bdb072e92c1363e5f7a4c1842eaf95f77b21"
+  integrity sha512-h+0mA4cHmzL4BhyCniB6ZSSZhfO9LpXXbnhdAfa2k7klS03woiOT+Dh5AchY6eoQXk3vQVtqn40YY3u+MwFs8A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@*", "@types/react-dom@^16.9.5":
   version "16.9.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.5.tgz#5de610b04a35d07ffd8f44edad93a71032d9aaa7"
@@ -3843,6 +3850,13 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+css-box-model@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.0.tgz#3a26377b4162b3200d2ede4b064ec5b6a75186d0"
+  integrity sha512-lri0br+jSNV0kkkiGEp9y9y3Njq2PmpqbeGWRFQJuZteZzY9iC9GZhQ8Y4WpPwM/2YocjHePxy14igJY7YKzkA==
+  dependencies:
+    tiny-invariant "^1.0.6"
 
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
@@ -7074,6 +7088,11 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+memoize-one@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
+
 memoizerific@^1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/memoizerific/-/memoizerific-1.11.3.tgz#7c87a4646444c32d75438570905f2dbd1b1a805a"
@@ -8723,6 +8742,11 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
+raf-schd@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
+  integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
+
 ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
@@ -8774,6 +8798,24 @@ react-addons-create-fragment@^15.6.2:
     fbjs "^0.8.4"
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
+
+react-beautiful-dnd-test-utils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd-test-utils/-/react-beautiful-dnd-test-utils-3.1.0.tgz#371d5e08cdc28e2582c79d9bca9f7cc5d2eccb96"
+  integrity sha512-SZqRz5bfuzo1+SMIq2pS9vhRli7+X1m6Q8/HszZDVEoXPU3J+91D5Mz7P6MrJXYtVT5+XHOYo1T2QdwjkQ4qmQ==
+
+react-beautiful-dnd@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.0.0.tgz#f70cc8ff82b84bc718f8af157c9f95757a6c3b40"
+  integrity sha512-87It8sN0ineoC3nBW0SbQuTFXM6bUqM62uJGY4BtTf0yzPl8/3+bHMWkgIe0Z6m8e+gJgjWxefGRVfpE3VcdEg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.1.1"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
 
 react-clientside-effect@^1.2.2:
   version "1.2.2"
@@ -8907,6 +8949,11 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.3, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
+react-is@^16.9.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -8932,6 +8979,17 @@ react-popper@^1.3.6:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-redux@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-sizeme@^2.6.7:
   version "2.6.12"
@@ -9067,6 +9125,14 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+redux@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 refractor@^2.4.1:
   version "2.10.1"
@@ -10161,6 +10227,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
 symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -10298,6 +10369,11 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tiny-invariant@^1.0.6:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -10708,6 +10784,11 @@ use-callback-ref@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.1.tgz#898759ccb9e14be6c7a860abafa3ffbd826c89bb"
   integrity sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==
+
+use-memo-one@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
+  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
 
 use-sidecar@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Changes

Add `ColumnControl` modal component to control visibility and order of columns within the table. Modal visibility can be controlled using the `open` and `toggle` props on the `ColumnControl` component.

Column ordering is enabled by adding the react-table plugin `useColumnOrder`

Defaults can be set for visibility and order on the table options prop by using `initialState.hiddenColumns` and `initialState.columnOrder` keys. Each take an array of column id's.


The ColumnControl modal also contains a reset button that respects the `initialState` key on table options for both `hiddenColumns` and `columnOrder`