### PR TITLE
Fix Column Control List Order

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,8 @@ export default {
     commonjs({
       extensions: ['.js', '.ts'],
       namedExports: {
-        'react-table': Object.keys(reactTable)
+        'react-table': Object.keys(reactTable),
+        'node_modules/react-redux/node_modules/react-is/index.js': ['isValidElementType', 'isContextConsumer']
       }
     }),
     postcss({

--- a/src/ColumnControl/ColumnControl.tsx
+++ b/src/ColumnControl/ColumnControl.tsx
@@ -28,6 +28,12 @@ const ColumnControl: React.FC<ColumnControlProps> = (props) => {
 
   const canOrderColumns = !!state.columnOrder
 
+  const columnOrder = state.columnOrder || []
+
+  const columns = allColumns.sort((a, b) => {
+    return columnOrder.indexOf(a.id) - columnOrder.indexOf(b.id)
+  })
+
   const reset = () => {
     setHiddenColumns(initialState.hiddenColumns || [])
     if (canOrderColumns) {
@@ -61,10 +67,10 @@ const ColumnControl: React.FC<ColumnControlProps> = (props) => {
         {canOrderColumns
           ? (
             <DragDropContext onDragEnd={dnd.onDragEnd}>
-              <ColumnList columns={allColumns} draggable={true} />
+              <ColumnList columns={columns} draggable={true} />
             </DragDropContext>
           ) : (
-              <ColumnList columns={allColumns} />
+              <ColumnList columns={columns} />
           )
         }
       </ModalBody>

--- a/tests/ColumnControl.test.tsx
+++ b/tests/ColumnControl.test.tsx
@@ -135,7 +135,38 @@ test('Reset Column Visiblity with initialState', async () => {
   })
 });
 
-test('Rearrange Columns without initialState', async () => {
+test('Dragging column control item changes its order', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }} plugins={[useColumnOrder]}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId } = render(<Component />)
+
+  // Verify starting order
+  const controlItems = getAllByTestId('column-control-item')
+  expect(controlItems[0].textContent).toBe('First Name')
+  expect(controlItems[1].textContent).toBe('Last Name')
+
+  // Drag first name
+  const firstNameControl = controlItems[0]
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 40 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+
+  await waitFor(() => {
+    // Verify order after sort
+    const controlItems = getAllByTestId('column-control-item')
+    expect(controlItems[0].textContent).toBe('Last Name')
+    expect(controlItems[1].textContent).toBe('First Name')
+  })
+});
+
+test('Rearrange column list will reorder table columns', async () => {
   const Component = () => {
     return (
       <TableContext options={{ columns, data }} plugins={[useColumnOrder]}>


### PR DESCRIPTION
## Issue

When dragging a column control item to reorder the table columns, the control list would revert back to the default column order. The table columns and state would be updated by the column control list would display an incorrect order.

## Changes
 
Sort columns using the column order in the table state and add a test to verify column control order after drag and drop.