### PR TITLE
Load Table State from LocalStorage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,8 @@ module.exports = {
     "^.+\\.tsx?$": "ts-jest"
   },
   setupFilesAfterEnv: [
-    "@testing-library/jest-dom/extend-expect"
+    "@testing-library/jest-dom/extend-expect",
+    "jest-localstorage-mock"
   ],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"]
 };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-loader": "^8.0.6",
     "bootstrap": "^4.4.1",
     "jest": "^25.1.0",
+    "jest-localstorage-mock": "^2.4.0",
     "reactstrap": "^8.4.1",
     "regenerator-runtime": "^0.13.5",
     "rollup": "^2.0.5",

--- a/stories/ColumnControl-with-storage.stories..tsx
+++ b/stories/ColumnControl-with-storage.stories..tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Table, TableContext, ColumnControl, useTableContext } from '../src';
+
+import 'bootstrap/dist/css/bootstrap.min.css'
+import { Container, Row, Col, Button } from 'reactstrap';
+import { useColumnOrder } from 'react-table';
+
+export default {
+  title: 'reactstrap-table',
+  component: Table
+}
+
+const State = () => {
+  const table = useTableContext()
+  return (
+    <pre>
+      {JSON.stringify(table.state, null, 2)}
+    </pre>
+  )
+}
+
+export const ColumnControlStorageExample = () => {
+  const [ open, setOpen ] = React.useState(false)
+  const columns = React.useMemo(() => [
+    { Header: 'First Name', accessor: 'firstname'},
+    { Header: 'Last Name', accessor: 'lastname'}
+  ], [])
+
+  const data = React.useMemo(() => [
+    { firstname: 'John', lastname: 'Doe' },
+    { firstname: 'Jane', lastname: 'Smith'}
+  ], [])
+
+  return (
+    <Container fluid>
+      <Row>
+        <Col>
+          <TableContext options={{ columns, data }} storageKey='my-table' plugins={[useColumnOrder]}>
+            <Button onClick={() => setOpen(s => !s)}>Open Settings</Button>
+            <ColumnControl open={open} toggle={() => setOpen(o => !o)}/>
+            <Table />
+            <State />
+          </TableContext>
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+ColumnControlStorageExample.story = {
+  name: 'Column Control with Storage',
+};

--- a/tests/ColumnControl.test.tsx
+++ b/tests/ColumnControl.test.tsx
@@ -254,3 +254,159 @@ test('Reset after rearrange columns with initialState', async () => {
     expect(ths_post_reset[1].textContent).toBe('First Name')
   })
 });
+
+test('Rearrange column list will reorder table columns', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }} plugins={[useColumnOrder]}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId } = render(<Component />)
+
+  // Verify starting order
+  const ths = getAllByTestId('table-thead-tr-th')
+  expect(ths[0].textContent).toBe('First Name')
+  expect(ths[1].textContent).toBe('Last Name')
+
+  // Drag first name
+  const firstNameControl = getAllByTestId('column-control-item')[0]
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 40 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+
+  await waitFor(() => {
+    // Verify order after sort
+    const ths_post_drag = getAllByTestId('table-thead-tr-th')
+    expect(ths_post_drag[0].textContent).toBe('Last Name')
+    expect(ths_post_drag[1].textContent).toBe('First Name')
+  })
+});
+
+test('Reset after rearrange columns without initialState', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }} plugins={[useColumnOrder]}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId, getByTestId } = render(<Component />)
+
+  // Drag first name
+  const firstNameControl = getAllByTestId('column-control-item')[0]
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 40 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+  
+  // Reset Columns
+  fireEvent.click(getByTestId('reset-columns'))
+
+  await waitFor(() => {
+    // Verify order after sort
+    const ths_post_reset = getAllByTestId('table-thead-tr-th')
+    expect(ths_post_reset[0].textContent).toBe('First Name')
+    expect(ths_post_reset[1].textContent).toBe('Last Name')
+  })
+});
+
+test('Reset after rearrange columns with initialState', async () => {
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data, initialState: { columnOrder: ['lastname', 'firstname']}}} plugins={[useColumnOrder]}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId, getByTestId } = render(<Component />)
+
+  // Drag first name
+  const lastNameControl = getAllByTestId('column-control-item')[0]
+  fireEvent.keyDown(lastNameControl, { keyCode: 32 });
+  fireEvent.keyDown(lastNameControl, { keyCode: 40 });
+  fireEvent.keyDown(lastNameControl, { keyCode: 32 });
+  
+  // Reset Columns
+  fireEvent.click(getByTestId('reset-columns'))
+
+  await waitFor(() => {
+    // Verify order after sort
+    const ths_post_reset = getAllByTestId('table-thead-tr-th')
+    expect(ths_post_reset[0].textContent).toBe('Last Name')
+    expect(ths_post_reset[1].textContent).toBe('First Name')
+  })
+});
+
+test('LocalStorage was updated after column is hidden', async () => {
+  const key = 'test-table'
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }} plugins={[useColumnOrder]} storageKey={key}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId } = render(<Component />)
+
+  const visiblityControls= getAllByTestId('column-visibility-icon-visible')
+  expect(visiblityControls.length).toBe(2)
+  fireEvent.click(visiblityControls[0])
+
+  await waitFor(() => {
+    getAllByTestId('column-control-item')
+    const storageString = localStorage.getItem(key) 
+    const storage = storageString ? JSON.parse(storageString) : undefined
+    const expectedStorage = {
+      hiddenColumns: [
+        "firstname"
+      ],
+      columnOrder: []
+    }
+    expect(storage).toEqual(expectedStorage)
+  })
+});
+
+test('LocalStorage was updated after drag', async () => {
+  const key = 'test-table'
+  const Component = () => {
+    return (
+      <TableContext options={{ columns, data }} plugins={[useColumnOrder]} storageKey={key}>
+        <ColumnControl open={true} toggle={() => null} />
+        <Table />
+      </TableContext>
+    )
+  }
+
+  const { getAllByTestId } = render(<Component />)
+
+  const controlItems = getAllByTestId('column-control-item')
+
+  // Drag first name
+  const firstNameControl = controlItems[0]
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 40 });
+  fireEvent.keyDown(firstNameControl, { keyCode: 32 });
+
+  await waitFor(() => {
+    getAllByTestId('column-control-item')
+    const storageString = localStorage.getItem(key) 
+    const storage = storageString ? JSON.parse(storageString) : undefined
+    const expectedStorage = {
+      hiddenColumns: [],
+      columnOrder: [
+        "lastname",
+        "firstname"
+      ]
+    }
+    expect(storage).toEqual(expectedStorage)
+  })
+});

--- a/tests/table.test.tsx
+++ b/tests/table.test.tsx
@@ -82,3 +82,22 @@ test('Use context without provider should throw', () => {
 
   expect(() => render(<Component />)).toThrow()
 });
+
+test('Load table state from localStorage', () => {
+  const key = 'test-table'
+  localStorage.setItem(key, '{ "hiddenColumns": [ "lastname" ] }')
+
+  const Component = () => {
+    return (
+      <>
+        <TableContext options={{ columns, data }} storageKey={key}>
+          <Table />
+        </TableContext>
+      </>
+    ) 
+  }
+
+  const { getAllByTestId } = render(<Component />)
+  const ths = getAllByTestId('table-thead-tr-th')
+  expect(ths.length).toBe(1)
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6450,6 +6450,11 @@ jest-leak-detector@^25.1.0:
     jest-get-type "^25.1.0"
     pretty-format "^25.1.0"
 
+jest-localstorage-mock@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.4.0.tgz#c6073810735dd3af74020ea6c3885ec1cc6d0d13"
+  integrity sha512-/mC1JxnMeuIlAaQBsDMilskC/x/BicsQ/BXQxEOw+5b1aGZkkOAqAF3nu8yq449CpzGtp5jJ5wCmDNxLgA2m6A==
+
 jest-matcher-utils@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz#fa5996c45c7193a3c24e73066fc14acdee020220"
@@ -8798,11 +8803,6 @@ react-addons-create-fragment@^15.6.2:
     fbjs "^0.8.4"
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
-
-react-beautiful-dnd-test-utils@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd-test-utils/-/react-beautiful-dnd-test-utils-3.1.0.tgz#371d5e08cdc28e2582c79d9bca9f7cc5d2eccb96"
-  integrity sha512-SZqRz5bfuzo1+SMIq2pS9vhRli7+X1m6Q8/HszZDVEoXPU3J+91D5Mz7P6MrJXYtVT5+XHOYo1T2QdwjkQ4qmQ==
 
 react-beautiful-dnd@^13.0.0:
   version "13.0.0"


### PR DESCRIPTION
## Changes

Using the `storageKey` prop on `TableContext`, the table state will be loaded and stored within the browsers local storage.

### Tests

Tests were added to verify storage is loaded when the table mounts and that storage is updated on state change.
