### PR TITLE
Responsive table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imcva/reactstrap-table",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "React table used for sorting, searching, and filtering",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imcva/reactstrap-table",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React table used for sorting, searching, and filtering",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -18,6 +18,10 @@ interface SortProps {
   desc?: boolean
 }
 
+interface HeaderProps {
+  stickyHeader?: boolean
+}
+
 const Sort: React.FC<SortProps> = (props) => {
   if (props.sorted) {
     return props.desc
@@ -67,11 +71,12 @@ const Tr: React.FC<TrProps> = (props) => {
   )
 }
 
-const Header: React.FC = (props) => {
+
+const Header: React.FC<HeaderProps> = (props) => {
   const { headerGroups } = useTableContext()
 
   return (
-    <thead data-testid={'table-thead'}>
+    <thead className={props.stickyHeader ? 'sticky-header' : ''} data-testid={'table-thead'}>
       {headerGroups.map((headerGroup, index) => (
         <Tr headerGroup={headerGroup} key={index} />
       ))}

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -5,11 +5,16 @@ import Body from './Body'
 import useTableContext from './useTableContext'
 import TableContext, { Context, TableProps } from './TableContext'
 
-type OptionalTableProps = Partial<TableProps>
+import './table.css'
 
 interface BaseTableProps {
+  responsive?: boolean
+  responsiveHeight?: string
+  stickyHeader?: boolean
   "data-testid"?: string
 }
+
+type OptionalTableProps = Partial<TableProps> & BaseTableProps
 
 /**
  * Base Table component with no context injection.
@@ -20,10 +25,12 @@ const BaseTable: React.FC<BaseTableProps> = (props) => {
   const { getTableProps } = useTableContext() 
 
   return (
-    <StrapTable data-testid={ props['data-testid'] || 'table' } {...getTableProps()}>
-      <Header />
-      <Body />
-    </StrapTable>
+    <div className={props.responsive ? 'table-responsive' : ''} style={{maxHeight: props.responsiveHeight}}>
+      <StrapTable data-testid={ props['data-testid'] || 'table' } {...getTableProps()}>
+        <Header stickyHeader={props.stickyHeader} /> 
+        <Body />
+      </StrapTable>
+    </div>
   )
 }
 
@@ -45,11 +52,21 @@ const Table: React.FC<OptionalTableProps> = (props) => {
   if (tableState === null && props.options) {
     return (
       <TableContext options={props.options} plugins={props.plugins}>
-        <BaseTable />  
+        <BaseTable
+          responsive={props.responsive}
+          responsiveHeight={props.responsiveHeight}
+          stickyHeader={props.stickyHeader}
+        />
       </TableContext>
     )
   } else if (tableState !== null ) {
-    return <BaseTable />
+    return (
+      <BaseTable
+        responsive={props.responsive}
+        responsiveHeight={props.responsiveHeight}
+        stickyHeader={props.stickyHeader}
+      />
+    )
   }
   return null
  }

--- a/src/table.css
+++ b/src/table.css
@@ -1,0 +1,24 @@
+thead.sticky-header th {
+  position: sticky;
+  top: 0;
+  background-color: white;
+  border: none !important;
+}
+
+thead.sticky-header th:before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  border-bottom: 1px solid #dee2e6;
+}
+
+thead.sticky-header th:after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  border-bottom: 2px solid #dee2e6;
+}

--- a/stories/responsive.stories.tsx
+++ b/stories/responsive.stories.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { Table } from '../src';
+
+import 'bootstrap/dist/css/bootstrap.min.css'
+import { Container, Row, Col } from 'reactstrap';
+
+export default {
+  title: 'reactstrap-table',
+  component: Table,
+}
+
+export const ResponsiveVertical = () => {
+  const columns = [
+    { Header: 'First Name', accessor: 'firstname'},
+    { Header: 'Last Name', accessor: 'lastname'}
+  ]
+
+  const data = [
+    {firstname:"Olga",lastname:"Gerasch"},
+    {firstname:"Mateo",lastname:"Ferrettino"},
+    {firstname:"Darrin",lastname:"Giacomoni"},
+    {firstname:"Julie",lastname:"Scoggan"},
+    {firstname:"Anson",lastname:"Hancox"},
+    {firstname:"Gusella",lastname:"Cicculini"},
+    {firstname:"Cary",lastname:"Lendon"},
+    {firstname:"Bobine",lastname:"Hunnaball"},
+    {firstname:"Joanie",lastname:"Barthram"},
+    {firstname:"Gigi",lastname:"Derricoat"},
+    {firstname:"Renaud",lastname:"Prendeguest"},
+    {firstname:"Dyna",lastname:"Casper"},
+    {firstname:"Travers",lastname:"Boribal"},
+    {firstname:"Bert",lastname:"Giorgi"},
+    {firstname:"Nyssa",lastname:"Hancke"},
+    {firstname:"Eddy",lastname:"Camies"},
+    {firstname:"Beau",lastname:"Lapthorne"},
+    {firstname:"Cindelyn",lastname:"Highwood"},
+    {firstname:"Vasilis",lastname:"Plumstead"},
+    {firstname:"Garrick",lastname:"Clemo"},
+    {firstname:"Evvie",lastname:"Devil"},
+    {firstname:"Mariska",lastname:"Dumbelton"},
+    {firstname:"Reid",lastname:"Serfati"},
+    {firstname:"Othello",lastname:"Chuney"},
+    {firstname:"Wes",lastname:"Lefort"},
+    {firstname:"Kaylee",lastname:"Roddan"},
+    {firstname:"Virge",lastname:"Yatman"},
+    {firstname:"Kathye",lastname:"Karel"},
+    {firstname:"Kamilah",lastname:"Krugmann"},
+    {firstname:"Glad",lastname:"McNutt"},
+    {firstname:"Hermina",lastname:"Wyett"},
+    {firstname:"Pepillo",lastname:"Morton"},
+    {firstname:"Clemmy",lastname:"Hoyer"},
+    {firstname:"Osborne",lastname:"Swiggs"},
+    {firstname:"Lenka",lastname:"Leap"},
+    {firstname:"Suzann",lastname:"Ganders"},
+    {firstname:"Ingra",lastname:"Jiggen"},
+    {firstname:"Alvin",lastname:"Downe"},
+    {firstname:"Filippa",lastname:"Benedicto"},
+    {firstname:"Bennie",lastname:"Aizikowitz"},
+    {firstname:"Morry",lastname:"Riste"},
+    {firstname:"Ginnie",lastname:"Starr"},
+    {firstname:"Gannon",lastname:"Whawell"},
+    {firstname:"Kermit",lastname:"Spafford"},
+    {firstname:"Colline",lastname:"Leipoldt"},
+    {firstname:"Aubrey",lastname:"Raspin"},
+    {firstname:"Yard",lastname:"Curness"},
+    {firstname:"Rafaelita",lastname:"Crumpton"},
+    {firstname:"Ettore",lastname:"Chishull"},
+    {firstname:"Lena",lastname:"Palay"}
+  ]
+
+  return (
+    <Container fluid>
+      <Row>
+        <Col>
+          <Table stickyHeader responsive responsiveHeight='250px' options={{columns, data}} />
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+ResponsiveVertical.story = {
+  name: 'Responsive - Vertical',
+};
+
+export const ResponsiveHorizontal = () => {
+  const columns = [
+    { Header: 'First Name', accessor: 'firstname'},
+    { Header: 'Last Name', accessor: 'lastname'},
+    { Header: 'Gender', accessor: 'gender'},
+    { Header: 'Age', accessor: 'age'},
+    { Header: 'E-Mail', accessor: 'email'},
+    { Header: 'Phone', accessor: 'phone'},
+    { Header: 'Address', accessor: 'address'},
+    { Header: 'City', accessor: 'city'},
+    { Header: 'State', accessor: 'state'},
+    { Header: 'Zipcode', accessor: 'zipcode'}
+  ]
+
+  const data = [
+    {firstname:"Collie",lastname:"Heavyside",email:"cheavyside0@cbsnews.com",gender:"Female",address:"3 Elgar Pass",city:"Fayetteville",state:"North Carolina",zipcode:"28305"},
+    {firstname:"Prinz",lastname:"Hards",email:"phards1@quantcast.com",gender:"Male",address:"62 Laurel Hill",city:"Portland",state:"Oregon",zipcode:"97206"},
+    {firstname:"Puff",lastname:"Cucinotta",email:"pcucinotta2@xinhuanet.com",gender:"Male",address:"80921 Scott Court",city:"Pasadena",state:"California",zipcode:"91117"},
+    {firstname:"Collete",lastname:"Guyet",email:"cguyet3@github.io",gender:"Female",address:"11 Sloan Court",city:"Kent",state:"Washington",zipcode:"98042"},
+    {firstname:"Marsha",lastname:"Loudon",email:"mloudon4@multiply.com",gender:"Female",address:"1061 Mosinee Junction",city:"Houston",state:"Texas",zipcode:"77035"}
+  ]
+
+  return (
+    <Container fluid>
+      <Row>
+        <Col md={6}>
+          <Table responsive options={{columns, data}} />
+        </Col>
+      </Row>
+    </Container>
+  )
+}
+
+ResponsiveHorizontal.story = {
+  name: 'Responsive - Horizontal',
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,6 @@
   },
   "include": [
     "src/**/*",
-    "tests/**/*",
-    "stories/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Changes

Setup table to be responsive vertically and horizontally with sticky header option.

### Vertically Responsive

 - Set `responsiveHeight` prop to set the max height of the table.
 - Set `stickyHeader` prop to stick the table header to the top when scrolling

### Horizontal Responsive

 - Set `responsive` prop to set horizontal scrolling when the table doesn't fit on the page